### PR TITLE
Add warning about new OW API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Enter your city's name (Required)
 Enter your OpenWeather API Key here (Required)
 
 _A free OpenWeather API key is required for the plugin to work.
-Go to https://openweathermap.org to register and get a key._
+Go to https://openweathermap.org to register and get a key. (Warning: Perhaps the new key will become active within a few hours. If you encounter an error in the plugin after creating a new key, try just waiting a little)_
 
 _Direct link to signup page https://home.openweathermap.org/users/sign_up_.
 


### PR DESCRIPTION
After installing the plugin, I encountered a 401 error... After a little understanding of the code, I realized that the error was not on the plugin's side. In the OpenWeather FAQ, I found a mention that the new key does not become active immediately.

It seems to me that it would be nice to mention this in the README for new users.